### PR TITLE
feat(api): Added API Rate Limiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8949,6 +8949,11 @@
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "dev": true
     },
+    "p-ratelimit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/p-ratelimit/-/p-ratelimit-1.0.1.tgz",
+      "integrity": "sha512-tKBGoow6aWRH68K2eQx+qc1gSegjd5VLirZYc1Yms9pPFsYQ9TFI6aMn0vJH2vmvzjNpjlWZOFft4aPUen2w0A=="
+    },
     "p-reduce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "jsrsasign": "^10.5.1"
+    "jsrsasign": "^10.5.1",
+    "p-ratelimit": "^1.0.1"
   },
   "bugs": {
     "url": "https://github.com/CS3-Marketing/zoominfo-node-sdk/issues"

--- a/src/helpers/Api/Api.ts
+++ b/src/helpers/Api/Api.ts
@@ -1,4 +1,5 @@
 import axios, {AxiosError, AxiosResponse} from 'axios';
+import {pRateLimit} from 'p-ratelimit';
 import ZoomInfoException from '../Exception/ZoomInfoException';
 
 export default class Api {
@@ -6,8 +7,15 @@ export default class Api {
 
   private apiURL = 'https://api.zoominfo.com';
 
+  private limit;
+
   constructor(accessToken: string) {
     this.accessToken = accessToken;
+    this.limit = pRateLimit({
+      interval: 1000,
+      rate: 25,
+      concurrency: 25,
+    });
   }
 
   /**
@@ -16,17 +24,19 @@ export default class Api {
    * @returns AxiosRespone
    */
   protected async get(endpoint: string): Promise<AxiosResponse<any>> {
-    return axios
-      .get(`${this.apiURL}${endpoint}`, {
-        headers: {Authorization: 'Bearer ' + this.accessToken},
-      })
-      .then((res: AxiosResponse) => res)
-      .catch((err: AxiosError) => {
-        if (err.response) {
-          const errorStatus = err.response.status;
-          throw new ZoomInfoException(errorStatus, err.message, err.response.data);
-        } else throw new ZoomInfoException(500, err.message);
-      });
+    return this.limit(async (): Promise<AxiosResponse<any>> => {
+      return axios
+        .get(`${this.apiURL}${endpoint}`, {
+          headers: {Authorization: 'Bearer ' + this.accessToken},
+        })
+        .then((res: AxiosResponse) => res)
+        .catch((err: AxiosError) => {
+          if (err.response) {
+            const errorStatus = err.response.status;
+            throw new ZoomInfoException(errorStatus, err.message, err.response.data);
+          } else throw new ZoomInfoException(500, err.message);
+        });
+    });
   }
 
   /**
@@ -36,17 +46,19 @@ export default class Api {
    * @returns AxiosRespone
    */
   protected async post(endpoint: string, data: any): Promise<AxiosResponse<any>> {
-    return axios
-      .post(`${this.apiURL}${endpoint}`, data, {
-        headers: {Authorization: 'Bearer ' + this.accessToken},
-      })
-      .then((res: AxiosResponse) => res)
-      .catch((err: AxiosError) => {
-        if (err.response) {
-          const errorStatus = err.response.status;
-          throw new ZoomInfoException(errorStatus, err.message, err.response.data);
-        } else throw new ZoomInfoException(500, err.message);
-      });
+    return this.limit(async (): Promise<AxiosResponse<any>> => {
+      return axios
+        .post(`${this.apiURL}${endpoint}`, data, {
+          headers: {Authorization: 'Bearer ' + this.accessToken},
+        })
+        .then((res: AxiosResponse) => res)
+        .catch((err: AxiosError) => {
+          if (err.response) {
+            const errorStatus = err.response.status;
+            throw new ZoomInfoException(errorStatus, err.message, err.response.data);
+          } else throw new ZoomInfoException(500, err.message);
+        });
+    });
   }
 
   /**
@@ -56,17 +68,19 @@ export default class Api {
    * @returns AxiosResponse
    */
   protected async put(endpoint: string, data: any): Promise<AxiosResponse<any>> {
-    return axios
-      .put(`${this.apiURL}${endpoint}`, data, {
-        headers: {Authorization: 'Bearer ' + this.accessToken},
-      })
-      .then((res: AxiosResponse) => res)
-      .catch((err: AxiosError) => {
-        if (err.response) {
-          const errorStatus = err.response.status;
-          throw new ZoomInfoException(errorStatus, err.message, err.response.data);
-        } else throw new ZoomInfoException(500, err.message);
-      });
+    return this.limit(async (): Promise<AxiosResponse<any>> => {
+      return axios
+        .put(`${this.apiURL}${endpoint}`, data, {
+          headers: {Authorization: 'Bearer ' + this.accessToken},
+        })
+        .then((res: AxiosResponse) => res)
+        .catch((err: AxiosError) => {
+          if (err.response) {
+            const errorStatus = err.response.status;
+            throw new ZoomInfoException(errorStatus, err.message, err.response.data);
+          } else throw new ZoomInfoException(500, err.message);
+        });
+    });
   }
 
   /**
@@ -75,16 +89,18 @@ export default class Api {
    * @returns AxiosRespone
    */
   protected async delete(endpoint: string): Promise<AxiosResponse<any>> {
-    return axios
-      .delete(`${this.apiURL}${endpoint}`, {
-        headers: {Authorization: 'Bearer ' + this.accessToken},
-      })
-      .then((res: AxiosResponse) => res)
-      .catch((err: AxiosError) => {
-        if (err.response) {
-          const errorStatus = err.response.status;
-          throw new ZoomInfoException(errorStatus, err.message, err.response.data);
-        } else throw new ZoomInfoException(500, err.message);
-      });
+    return this.limit(async (): Promise<AxiosResponse<any>> => {
+      return await axios
+        .delete(`${this.apiURL}${endpoint}`, {
+          headers: {Authorization: 'Bearer ' + this.accessToken},
+        })
+        .then((res: AxiosResponse) => res)
+        .catch((err: AxiosError) => {
+          if (err.response) {
+            const errorStatus = err.response.status;
+            throw new ZoomInfoException(errorStatus, err.message, err.response.data);
+          } else throw new ZoomInfoException(500, err.message);
+        });
+    });
   }
 }


### PR DESCRIPTION
To prevent spamming the ZoomInfo API with request rate limit library [p-limit](https://www.npmjs.com/package/p-ratelimit) has been added. 

- By default the ZoomInfo API limits you to 1500 requests per minute.
- The pRateLimit has been configured for this rate limiting, allowing 25 requests per 1 second interval.

```javascript
import {pRateLimit} from 'p-ratelimit';

const limit = pRateLimit({
  interval: 1000,
  rate: 25,
  concurrency: 25,
});
```